### PR TITLE
Fixed the warning generated by Swift 2.2

### DIFF
--- a/ArrayDiff.podspec
+++ b/ArrayDiff.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name        = "ArrayDiff"
-  s.version     = "1.2.0"
+  s.version     = "1.3.0"
   s.summary     = "ArrayDiff quickly computes the difference between two arrays, works great with UITableView/UICollectionView"
   s.homepage    = "https://github.com/Adlai-Holler/ArrayDiff"
   s.license     = { :type => "MIT" }

--- a/ArrayDiff/ArrayDiff.swift
+++ b/ArrayDiff/ArrayDiff.swift
@@ -62,8 +62,8 @@ public extension Array {
 				repeatedValue: 0)
 		)
 		
-        for i in (0...count).reverse() {
-            for j in (0...other.count).reverse() {
+		for i in (0...count).reverse() {
+			for j in (0...other.count).reverse() {
 				if i == count || j == other.count {
 					lengths[i][j] = 0
 				} else if elementsAreEqual(self[i], other[j]) {
@@ -76,7 +76,7 @@ public extension Array {
 		let commonIndexes = NSMutableIndexSet()
 		var i = 0, j = 0
 
-        while i < count && j < other.count {
+		while i < count && j < other.count {
 			if elementsAreEqual(self[i], other[j]) {
 				commonIndexes.addIndex(i)
 				i += 1
@@ -93,10 +93,10 @@ public extension Array {
 		
 		let commonObjects = self[commonIndexes]
 		let addedIndexes = NSMutableIndexSet()
-        i = 0
-        j = 0
-        
-        while i < commonObjects.count || j < other.count {
+		i = 0
+		j = 0
+		
+		while i < commonObjects.count || j < other.count {
 			if i < commonObjects.count && j < other.count && elementsAreEqual (commonObjects[i], other[j]) {
 				i += 1
 				j += 1

--- a/ArrayDiff/ArrayDiff.swift
+++ b/ArrayDiff/ArrayDiff.swift
@@ -31,8 +31,8 @@ public struct ArrayDiff {
 		var insertedAtOrBefore = 0
 		for i in insertedIndexes {
 			if i <= result  {
-				insertedAtOrBefore++
-				result++
+				insertedAtOrBefore += 1
+				result += 1
 			} else {
 				break
 			}
@@ -62,8 +62,8 @@ public extension Array {
 				repeatedValue: 0)
 		)
 		
-		for var i = count; i >= 0; i-- {
-			for var j = other.count; j >= 0; j-- {
+        for i in (0...count).reverse() {
+            for j in (0...other.count).reverse() {
 				if i == count || j == other.count {
 					lengths[i][j] = 0
 				} else if elementsAreEqual(self[i], other[j]) {
@@ -74,16 +74,17 @@ public extension Array {
 			}
 		}
 		let commonIndexes = NSMutableIndexSet()
-		
-		for var i = 0, j = 0; i < count && j < other.count; {
+		var i = 0, j = 0
+
+        while i < count && j < other.count {
 			if elementsAreEqual(self[i], other[j]) {
 				commonIndexes.addIndex(i)
-				i++
-				j++
+				i += 1
+				j += 1
 			} else if lengths[i+1][j] >= lengths[i][j+1] {
-				i++
+				i += 1
 			} else {
-				j++
+				j += 1
 			}
 		}
 		
@@ -92,13 +93,16 @@ public extension Array {
 		
 		let commonObjects = self[commonIndexes]
 		let addedIndexes = NSMutableIndexSet()
-		for var i = 0, j = 0; i < commonObjects.count || j < other.count; {
+        i = 0
+        j = 0
+        
+        while i < commonObjects.count || j < other.count {
 			if i < commonObjects.count && j < other.count && elementsAreEqual (commonObjects[i], other[j]) {
-				i++
-				j++
+				i += 1
+				j += 1
 			} else {
 				addedIndexes.addIndex(j)
-				j++
+				j += 1
 			}
 		}
 		

--- a/ArrayDiff/Section.swift
+++ b/ArrayDiff/Section.swift
@@ -5,7 +5,7 @@ Types that conform to this protocol represent a section of a table.
 - See: `NamedSection` for an example implementation
 */
 public protocol SectionType: Equatable {
-	typealias Item: Equatable
+	associatedtype Item: Equatable
 	var items: [Item] { get }
 }
 


### PR DESCRIPTION
I only bumped the minor version of the pod, but given that the changes are breaking for anyone < Swift 2.2 we can bump the major version to cover anyone who hasn't migrated to 2.2 yet.
